### PR TITLE
Use Storage queue output binding

### DIFF
--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -45,7 +45,9 @@
         "storageQueueName": "[concat(variables('storageAccountName'), '/default/widgets')]",
         "hostingPlanName": "[concat(parameters('baseName'), '-plan')]",
         "functionAppName": "[concat(parameters('baseName'),'-func')]",
-        "applicationInsightsName": "[concat(parameters('baseName'), '-ai')]"
+        "applicationInsightsName": "[concat(parameters('baseName'), '-ai')]",
+        "storageQueueRoleDefinitionId":"[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '974c5e8b-45b9-4653-ba55-5f855dd0fb88')]",
+        "storageQueueRoleAssignmentName":"[guid(resourceId('Microsoft.Web/sites', variables('functionAppName')), variables('storageQueueRoleDefinitionId'), '0a9dd9cc-3ac8-46c0-95ca-5c2e34be621e')]"
     },
     "resources": [
         {
@@ -166,6 +168,20 @@
                         }
                     ]
                 }
+            }
+        },
+        {
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2020-04-01-preview",
+            "name": "[variables('storageQueueRoleAssignmentName')]",
+            "scope": "[concat('Microsoft.Storage/storageAccounts', '/', variables('storageAccountName'))]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
+                "[resourceId('Microsoft.Web/sites', variables('functionAppName'))]"
+            ],
+            "properties": {
+                "roleDefinitionId": "[variables('storageQueueRoleDefinitionId')]",
+                "principalId": "[reference(resourceId('Microsoft.Web/sites', variables('functionAppName')), '2019-08-01', 'Full').identity.principalId]"
             }
         }
     ]

--- a/src/SampleFunction.cs
+++ b/src/SampleFunction.cs
@@ -13,11 +13,14 @@ namespace Collier.Functions
     public static class SampleFunction
     {
         [FunctionName("QueueTrigger")]
-        public static void RunQueueTrigger(
+        [return: Queue("%OutputQueueName%")]
+        public static QueueMessage RunQueueTrigger(
             [QueueTrigger("%QueueName%", Connection="MyStorageConnection" )] QueueMessage queueItem,
             ILogger log)
         {
             log.LogInformation($"C# function processed: {queueItem.MessageText}");
+
+            return queueItem.MessageText + "output";
         }
 
     //     [FunctionName("EventHubTriggerCSharp1")]

--- a/src/SampleFunction.cs
+++ b/src/SampleFunction.cs
@@ -13,14 +13,15 @@ namespace Collier.Functions
     public static class SampleFunction
     {
         [FunctionName("QueueTrigger")]
-        [return: Queue("%OutputQueueName%")]
-        public static QueueMessage RunQueueTrigger(
+        [return: Queue("%OutputQueueName%", Connection="MyStorageConnection")]
+        public static string RunQueueTrigger(
             [QueueTrigger("%QueueName%", Connection="MyStorageConnection" )] QueueMessage queueItem,
             ILogger log)
         {
             log.LogInformation($"C# function processed: {queueItem.MessageText}");
 
-            return queueItem.MessageText + "output";
+            string outputMessage = queueItem.MessageText + " output";
+            return outputMessage;
         }
 
     //     [FunctionName("EventHubTriggerCSharp1")]


### PR DESCRIPTION
Example showing how to use a queue trigger and queue output binding via managed identity.  Currently using a `string` type for the output binding.

Sets up RBAC for the managed identity of the function app in order to be able to work with the Azure Storage queues.